### PR TITLE
PBM-720 Described the use of authSource and defaultauthdb

### DIFF
--- a/source/.res/code-block/bash/pbm-agent-mongodb-conn-string-examples.txt
+++ b/source/.res/code-block/bash/pbm-agent-mongodb-conn-string-examples.txt
@@ -1,6 +1,6 @@
 .. code-block:: bash
 
-   $ pbm-agent --mongodb-uri "mongodb://pbmuser:secretpwd@localhost:27018/"
+   $ pbm-agent --mongodb-uri "mongodb://pbmuser:secretpwd@localhost:27018/?authSource=admin"
    $ #Alternatively:
-   $ export PBM_MONGODB_URI="mongodb://pbmuser:secretpwd@localhost:27018/"
+   $ export PBM_MONGODB_URI="mongodb://pbmuser:secretpwd@localhost:27018/?authSource=admin"
    $ pbm-agent

--- a/source/.res/code-block/bash/pbm-cli-mongodb-conn-string-examples.txt
+++ b/source/.res/code-block/bash/pbm-cli-mongodb-conn-string-examples.txt
@@ -1,6 +1,6 @@
 .. code-block:: bash
 
-   $ pbm list --mongodb-uri "mongodb://pbmuser:secretpwd@mongocsvr1:27018,mongocsvr2:27018,mongocsvr3:27018/?replicaSet=configrs"
+   $ pbm list --mongodb-uri "mongodb://pbmuser:secretpwd@mongocsvr1:27018,mongocsvr2:27018,mongocsvr3:27018/?replicaSet=configrs&authSource=admin"
    $ #Alternatively:
-   $ export PBM_MONGODB_URI="mongodb://pbmuser:secretpwd@mongocsvr1:27018,mongocsvr2:27018,mongocsvr3:27018/?replicaSet=configrs"
+   $ export PBM_MONGODB_URI="mongodb://pbmuser:secretpwd@mongocsvr1:27018,mongocsvr2:27018,mongocsvr3:27018/?replicaSet=configrs&authSource=admin"
    $ pbm list

--- a/source/authentication.rst
+++ b/source/authentication.rst
@@ -32,6 +32,13 @@ since approximately the release time of MongoDB server v3.6. The ``mongo`` shell
 a v4.0+ mongo shell is a recommended way to debug connection URI validity from
 the command line.
 
+ Since |PBM| must authenticate in MongoDB, we recommend specifying the authentication database associated with the ``pbm`` user’s credentials in the connection URI string using the ``authSource`` option. 
+
+ The `MongoDB Connection URI <https://docs.mongodb.com/manual/reference/connection-string/>`_ specification also allows specifying the authentication database via the ``defaultauthdb`` component. However, in this case, |PBM| makes a backup of only this specified database. 
+
+ If both ``authSource`` and ``defaultauthdb`` are unspecified, the authentication database defaults to the ``admin`` database.
+
+
 The `MongoDB Connection URI
 <https://docs.mongodb.com/manual/reference/connection-string/>`_ specification
 includes several non-default options you may need to use. For example the TLS


### PR DESCRIPTION
modified:   source/.res/code-block/bash/pbm-agent-mongodb-conn-string-examples.txt
	modified:   source/.res/code-block/bash/pbm-cli-mongodb-conn-string-examples.txt
	modified:   source/authentication.rst