### PR TITLE
s3 remote storage - adds the PrivateLink case

### DIFF
--- a/docs/install/initial-setup.md
+++ b/docs/install/initial-setup.md
@@ -229,6 +229,21 @@ The storage configuration itself is out of scope of the present document. We ass
           kmsKeyID: <your-kms-key-here>
     ```
 
+    !!! tip
+
+    If you are using AWS PrivateLink, the s3 endpoint needs to be specified explicitly. You can use the option `endpointUrl` for this scope, like in the following example:
+
+   ```yaml
+   ...
+   s3:
+     region: us-west-2
+     bucket: pbm-test-bucket
+     prefix: data/pbm/backup
+     endpointUrl: https://your-endpoint-url-here
+     ...
+   ```
+
+   
     This is the sample configuration for Microsoft Azure Blob storage:
 
     ```yaml
@@ -254,7 +269,7 @@ The storage configuration itself is out of scope of the present document. We ass
     See more examples in [Configuration file examples](../details/storage-config-example.md).
 
 
-3. Insert the config file
+4. Insert the config file
 
 ```{.bash data-prompt="$"}
 $ pbm config --file pbm_config.yaml

--- a/docs/install/initial-setup.md
+++ b/docs/install/initial-setup.md
@@ -231,19 +231,19 @@ The storage configuration itself is out of scope of the present document. We ass
 
     !!! tip
 
-    If you are using AWS PrivateLink, the s3 endpoint needs to be specified explicitly. You can use the option `endpointUrl` for this scope, like in the following example:
+        If you are using AWS PrivateLink, the s3 endpoint needs to be specified explicitly. You can use the option `endpointUrl` for this scope, like in the following example:
 
-   ```yaml
-   ...
-   s3:
-     region: us-west-2
-     bucket: pbm-test-bucket
-     prefix: data/pbm/backup
-     endpointUrl: https://your-endpoint-url-here
-     ...
-   ```
+       ```yaml
+       ...
+       s3:
+         region: us-west-2
+         bucket: pbm-test-bucket
+         prefix: data/pbm/backup
+         endpointUrl: https://your-endpoint-url-here
+         ...
+       ```
 
-   
+
     This is the sample configuration for Microsoft Azure Blob storage:
 
     ```yaml
@@ -269,7 +269,7 @@ The storage configuration itself is out of scope of the present document. We ass
     See more examples in [Configuration file examples](../details/storage-config-example.md).
 
 
-3. Insert the config file
+4. Insert the config file
 
 ```{.bash data-prompt="$"}
 $ pbm config --file pbm_config.yaml

--- a/docs/install/initial-setup.md
+++ b/docs/install/initial-setup.md
@@ -269,7 +269,7 @@ The storage configuration itself is out of scope of the present document. We ass
     See more examples in [Configuration file examples](../details/storage-config-example.md).
 
 
-4. Insert the config file
+3. Insert the config file
 
 ```{.bash data-prompt="$"}
 $ pbm config --file pbm_config.yaml

--- a/docs/install/initial-setup.md
+++ b/docs/install/initial-setup.md
@@ -233,15 +233,15 @@ The storage configuration itself is out of scope of the present document. We ass
 
         If you are using AWS PrivateLink, the s3 endpoint needs to be specified explicitly. You can use the option `endpointUrl` for this scope, like in the following example:
 
-       ```yaml
-       ...
-       s3:
-         region: us-west-2
-         bucket: pbm-test-bucket
-         prefix: data/pbm/backup
-         endpointUrl: https://your-endpoint-url-here
-         ...
-       ```
+        ```yaml
+        ...
+        s3:
+          region: us-west-2
+          bucket: pbm-test-bucket
+          prefix: data/pbm/backup
+          endpointUrl: https://your-endpoint-url-here
+          ...
+        ```
 
 
     This is the sample configuration for Microsoft Azure Blob storage:
@@ -269,7 +269,7 @@ The storage configuration itself is out of scope of the present document. We ass
     See more examples in [Configuration file examples](../details/storage-config-example.md).
 
 
-4. Insert the config file
+3. Insert the config file
 
 ```{.bash data-prompt="$"}
 $ pbm config --file pbm_config.yaml


### PR DESCRIPTION

`endpointUrl` might be needed in some cases, for instance when using AWS PrivateLink.

Thanks,

---

**Was:**

<img width="859" alt="was" src="https://github.com/percona/pbm-docs/assets/31849787/a7981edf-2f3a-48c1-a0ec-238fa05198cc">


**Now:**

<img width="763" alt="now" src="https://github.com/percona/pbm-docs/assets/31849787/b066afc7-8e2a-4bde-b53a-6a4a5f5e4709">
