### PR TITLE
PBM-1383 - highlight more word `every` and mention election process

### DIFF
--- a/docs/details/architecture.md
+++ b/docs/details/architecture.md
@@ -11,7 +11,7 @@ Percona Backup for MongoDB consists of the following components:
 * Remote backup storage is where Percona Backup for MongoDB saves backups. It can be either [an S3 compatible storage](../reference/glossary.md#s3-compatible-storage) or a filesystem-type storage.
 
 ??? info "Nomination and election process within PBM"
-     If the `pbm-agent` running on the primary node of the replica set or in the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. It is therefore required to ensure all the `pbm-agent` are up and running.
+     If the `pbm-agent` running on the primary node of the replica set or in the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. It is therefore required ensuring that all the `pbm-agent` processes are up and running.
 
 The following diagram illustrates how Percona Backup for MongoDB components communicate with MongoDB.
 

--- a/docs/details/architecture.md
+++ b/docs/details/architecture.md
@@ -11,7 +11,7 @@ Percona Backup for MongoDB consists of the following components:
 * Remote backup storage is where Percona Backup for MongoDB saves backups. It can be either [an S3 compatible storage](../reference/glossary.md#s3-compatible-storage) or a filesystem-type storage.
 
 ??? info "Nomination and election process within PBM"
-     If the `pbm-agent` running on the primary node of the replica set or in the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. It is therefore required ensuring that all the `pbm-agent` processes are up and running.
+     If the `pbm-agent` running on the primary node of the replica set or on the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. You must therefore ensure that all the `pbm-agent` processes are up and running.
 
 The following diagram illustrates how Percona Backup for MongoDB components communicate with MongoDB.
 

--- a/docs/details/architecture.md
+++ b/docs/details/architecture.md
@@ -2,7 +2,7 @@
 
 Percona Backup for MongoDB consists of the following components:
 
-* [`pbm-agent`](../reference/glossary.md#pbm-agent) is a process running on every `mongod` node within the cluster or within a replica set that performs backup and restore operations.
+* [`pbm-agent`](../reference/glossary.md#pbm-agent) is a process running on **every** `mongod` node within the cluster or within a replica set that performs backup and restore operations.
 
 * [`pbm` CLI](../reference/glossary.md#pbm-cli) is a command-line utility that instructs `pbm-agents` to perform an operation.
 
@@ -14,4 +14,3 @@ Percona Backup for MongoDB consists of the following components:
 The following diagram illustrates how Percona Backup for MongoDB components communicate with MongoDB.
 
 ![image](../_images/pbm-architecture.png){ align=center}
-

--- a/docs/details/architecture.md
+++ b/docs/details/architecture.md
@@ -10,6 +10,9 @@ Percona Backup for MongoDB consists of the following components:
 
 * Remote backup storage is where Percona Backup for MongoDB saves backups. It can be either [an S3 compatible storage](../reference/glossary.md#s3-compatible-storage) or a filesystem-type storage.
 
+??? info "Nomination and election process within PBM"
+     If the `pbm-agent` running on the primary node of the replica set or in the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. It is therefore required to ensure all the `pbm-agent` are up and running.
+
 The following diagram illustrates how Percona Backup for MongoDB components communicate with MongoDB.
 
 ![image](../_images/pbm-architecture.png){ align=center}

--- a/docs/details/architecture.md
+++ b/docs/details/architecture.md
@@ -10,9 +10,6 @@ Percona Backup for MongoDB consists of the following components:
 
 * Remote backup storage is where Percona Backup for MongoDB saves backups. It can be either [an S3 compatible storage](../reference/glossary.md#s3-compatible-storage) or a filesystem-type storage.
 
-??? info "Nomination and election process within PBM"
-     If the `pbm-agent` running on the primary node of the replica set or on the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. You must therefore ensure that all the `pbm-agent` processes are up and running.
-
 The following diagram illustrates how Percona Backup for MongoDB components communicate with MongoDB.
 
 ![image](../_images/pbm-architecture.png){ align=center}

--- a/docs/details/architecture.md
+++ b/docs/details/architecture.md
@@ -8,7 +8,6 @@ Percona Backup for MongoDB consists of the following components:
 
 * [PBM Control collections](../reference/glossary.md#pbm-control-collections) are special collections in MongoDB that store the configuration data and backup states. Both `pbm` CLI and `pbm-agent` use PBM Control collections to check backup status in MongoDB and communicate with each other.
 
-
 * Remote backup storage is where Percona Backup for MongoDB saves backups. It can be either [an S3 compatible storage](../reference/glossary.md#s3-compatible-storage) or a filesystem-type storage.
 
 The following diagram illustrates how Percona Backup for MongoDB components communicate with MongoDB.

--- a/docs/details/architecture.md
+++ b/docs/details/architecture.md
@@ -2,7 +2,7 @@
 
 Percona Backup for MongoDB consists of the following components:
 
-* [`pbm-agent`](../reference/glossary.md#pbm-agent) is a process running on **every** `mongod` node within the cluster or within a replica set that performs backup and restore operations.
+* [`pbm-agent`](../reference/glossary.md#pbm-agent) is a process running on **every** `mongod` node that is not an arbiter node within the cluster or within a replica set that performs backup and restore operations.
 
 * [`pbm` CLI](../reference/glossary.md#pbm-cli) is a command-line utility that instructs `pbm-agents` to perform an operation.
 

--- a/docs/details/pbm-agent.md
+++ b/docs/details/pbm-agent.md
@@ -2,7 +2,7 @@
 
 A `pbm-agent` is a process that runs backup, restore, delete, and other operations available with Percona Backup for MongoDB.
 
-A `pbm-agent` instance must run for each `mongod` instance that is not an arbiter node. This includes replica set nodes that are currently secondaries and config server replica set nodes in a sharded cluster.
+A `pbm-agent` instance must run for **every** `mongod` instance that is not an arbiter node. This includes replica set nodes that are currently secondaries and config server replica set nodes in a sharded cluster.
 
 An operation is triggered when the [`pbm` CLI](../reference/glossary.md#pbm-cli) makes an update to the [PBM Control collection](../reference/glossary.md#pbm-control-collections). All `pbm-agents` monitor changes to the PBM control collections, but only one `pbm-agent` in each replica set will be elected to execute an operation. The elections are done by a random choice among secondary nodes. If no secondary nodes respond, then the `pbm-agent` on the primary node is elected for an operation.
 

--- a/docs/details/pbm-agent.md
+++ b/docs/details/pbm-agent.md
@@ -9,7 +9,8 @@ An operation is triggered when the [`pbm` CLI](../reference/glossary.md#pbm-cli)
 The elected `pbm-agent` acquires a lock for an operation. This prevents mutually exclusive operations like backup and restore to be executed simultaneously.
 
 ??? info "Nomination and election process within PBM"
-     If the `pbm-agent` running on the primary node of the replica set or on the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. You must therefore ensure that all the `pbm-agent` processes are up and running.
+
+    If the `pbm-agent` running on the primary node of the replica set or on the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. You must therefore ensure that all the `pbm-agent` processes are up and running.
 
 When the operation is complete, the `pbm-agent` releases the lock and updates the PBM control collections.
 

--- a/docs/details/pbm-agent.md
+++ b/docs/details/pbm-agent.md
@@ -8,6 +8,9 @@ An operation is triggered when the [`pbm` CLI](../reference/glossary.md#pbm-cli)
 
 The elected `pbm-agent` acquires a lock for an operation. This prevents mutually exclusive operations like backup and restore to be executed simultaneously.
 
+??? info "Nomination and election process within PBM"
+     If the `pbm-agent` running on the primary node of the replica set or on the primary node of the config replica set fails, the backup will not start as these agents are responsible for internal nomination process. You must therefore ensure that all the `pbm-agent` processes are up and running.
+
 When the operation is complete, the `pbm-agent` releases the lock and updates the PBM control collections.
 
 A single `pbm-agent` is involved with only one cluster (or non-sharded replica set). The `pbm` CLI utility can connect to any cluster to which it has network access, so it is possible for one user to list and launch backups or restores on many clusters.

--- a/docs/details/pbm-agent.md
+++ b/docs/details/pbm-agent.md
@@ -2,7 +2,7 @@
 
 A `pbm-agent` is a process that runs backup, restore, delete, and other operations available with Percona Backup for MongoDB.
 
-A `pbm-agent` instance must run for each `mongod` instance. This includes replica set nodes that are currently secondaries and config server replica set nodes in a sharded cluster.
+A `pbm-agent` instance must run for each `mongod` instance that is not an arbiter node. This includes replica set nodes that are currently secondaries and config server replica set nodes in a sharded cluster.
 
 An operation is triggered when the [`pbm` CLI](../reference/glossary.md#pbm-cli) makes an update to the [PBM Control collection](../reference/glossary.md#pbm-control-collections). All `pbm-agents` monitor changes to the PBM control collections, but only one `pbm-agent` in each replica set will be elected to execute an operation. The elections are done by a random choice among secondary nodes. If no secondary nodes respond, then the `pbm-agent` on the primary node is elected for an operation.
 

--- a/docs/install/initial-setup.md
+++ b/docs/install/initial-setup.md
@@ -4,7 +4,7 @@ The following diagram outlines the installation and setup steps:
 
 ![image](../_images/setup.png)
 
-After you [installed Percona Backup for MongoDB](../installation.md) on every server with the `mongod` node that is not an arbiter node, complete the following setup steps:
+After you [installed Percona Backup for MongoDB](../installation.md) on **every** server with the `mongod` node that is not an arbiter node, complete the following setup steps:
 
 1. [Configure authentication in MongoDB](configure-authentication.md).
 


### PR DESCRIPTION
Adds a warning re PBM agents and election process.
Also, excludes arbiters in `architecture` and `pbm-agent` as done already on `initial-setup`.