### PR TITLE
Removed the repo config for ARM arch in install from repos doc

### DIFF
--- a/docs/install/repos.md
+++ b/docs/install/repos.md
@@ -15,40 +15,16 @@ Check the [system requirements](../system-requirements.md) and [supported MongoD
 
 ### Configure Percona repository
 
-=== "x86_64"
+Percona provides the [`percona-release` :material-arrow-top-right: ](https://docs.percona.com/percona-software-repositories/index.html) configuration tool that simplifies operating repositories and enables to install and update both Percona Backup for MongoDB packages and required dependencies smoothly. 
 
-    Percona provides the [`percona-release` :material-arrow-top-right: ](https://docs.percona.com/percona-software-repositories/index.html) configuration tool that simplifies operating repositories and enables to install and update both Percona Backup for MongoDB packages and required dependencies smoothly. 
+1. [Install `percona-release` :octicons-link-external-16:](https://www.percona.com/doc/percona-repo-config/installing.html).    
 
-    1. [Install `percona-release` :octicons-link-external-16:](https://www.percona.com/doc/percona-repo-config/installing.html).    
+2. Enable the repository    
 
-    2. Enable the repository    
+    ```{.bash data-prompt="$"}
+    $ sudo percona-release enable pbm release
+    ```
 
-        ```{.bash data-prompt="$"}
-        $ sudo percona-release enable pbm release
-        ```
-
-=== "ARM64"
-
-    === ":material-debian: On Debian and Ubuntu"
-
-        Create the `/etc/apt/sources.list.d/percona-pbm-release.list ` configuration file with the following contents:
-
-        ```ini title='/etc/apt/sources.list.d/percona-pbm-release.list'
-        deb http://repo.percona.com/pbm/apt OPERATING_SYSTEM main
-        ```
-    
-    === ":material-redhat: On Red Hat Enterprise Linux and derivatives"
-
-        Create the `/etc/yum.repos.d/percona-pbm-release.repo` configuration file with the following contents:
-
-        ```ini title='/etc/yum.repos.d/percona-pbm-release.repo'
-        [pbm-release-aarch64]
-        name = Percona Backup MongoDB release/aarch64 YUM repository
-        baseurl = http://repo.percona.com/pbm/yum/release/$releasever/RPMS/aarch64
-        enabled = 1
-        gpgcheck = 1
-        gpgkey = file:///etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY
-        ```
 
 ### Install Percona Backup for MongoDB packages
 


### PR DESCRIPTION
percona-release supports ARM 64 so there's no need for manual repo configuration

modified:   docs/install/repos.md