### PR TITLE
Fix docker link

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -1,6 +1,6 @@
 # Run Percona Backup for MongoDB in a Docker container
 
-Docker images of Percona Backup for MongoDB are hosted publicly on [Docker Hub :octicons-link-external-16:](https://hub.docker.com/repository/docker/percona/percona-backup-mongodb).
+Docker images of Percona Backup for MongoDB are hosted publicly on [Docker Hub :octicons-link-external-16:](https://hub.docker.com/r/percona/percona-backup-mongodb).
 
 For more information about using Docker, see the [Docker Docs :octicons-link-external-16:](https://docs.docker.com/).
 


### PR DESCRIPTION
- https://hub.docker.com/repository/docker/percona/percona-backup-mongodb requires login
- https://hub.docker.com/r/percona/percona-backup-mongodb seems the correct one, and similar to the link we are using in the documentation of other products

Thanks,