### PR TITLE
DOCS-179 Fixed more HMAC keys

### DIFF
--- a/docs/details/gcs.md
+++ b/docs/details/gcs.md
@@ -64,8 +64,8 @@ You can find [the configuration file template :octicons-link-external-16:](https
 		 bucket: pbm-testing
 		 prefix: pbm/test
 		 credentials:
-		   HMACAccessKey: <your-access-key-id-here>
-		   HMACSecret: <your-secret-key-here>
+		   hmacAccessKey: <your-access-key-id-here>
+		   hmacSecret: <your-secret-key-here>
 	```
 
 ## Adjust PBM configuration to use GCS


### PR DESCRIPTION
Google Cloud Storage (GCS) updated to match the [code](https://github.com/percona/percona-backup-mongodb/blob/v2.10.0/pbm/storage/gcs/gcs.go#L33).